### PR TITLE
Fixed an issue where actionbar on window1 was not updated after login.

### DIFF
--- a/app/widgets/com.capnajax.navigation/controllers/widget.js
+++ b/app/widgets/com.capnajax.navigation/controllers/widget.js
@@ -220,8 +220,11 @@ if(OS_IOS) {
 		
 		detail.title = _.last(detail.children).title;
 		
-		updateActionBar();
-		
+		if($.navigation.views.length == 1) {
+			$.widget.addEventListener('open', updateActionBar);
+		} else {
+			updateActionBar();
+		}
 	};
 	
 }


### PR DESCRIPTION
I noticed that on Android, the actionbar on Window1 screen was not updated. Since the window has not yet been opened yet, there was no associated activity. Modified to update the actionbar after window open if current window is the first window.
